### PR TITLE
facing error of stack too deep

### DIFF
--- a/contracts/GetUp.sol
+++ b/contracts/GetUp.sol
@@ -25,7 +25,6 @@ contract GetUp {
     struct Project {
         uint256 id;
         string name;
-        string host;
         uint256 joinFee;
         uint256 duration;
         uint256 penaltyFee; // 一度、寝坊した時にかかる費用
@@ -114,11 +113,9 @@ contract GetUp {
         uint256 _deadlineTime,
         uint256 _canJoinNumber
     ) public {
-        User storage user = users[msg.sender];
         projects.push(Project({
             id: projects.length, 
             name: _name,
-            host: user.name,
             joinFee: _joinFee,
             duration: _duration,
             penaltyFee: _penaltyFee,
@@ -130,7 +127,6 @@ contract GetUp {
             firstDeadlineTime: (bt / 86400 + _startXDaysLater) * 1 days + _deadlineTime * 1 hours,
             maxCanPenaltyNum: _joinFee / _penaltyFee
             }));
-            console.log("User name is %s",user.name);
     }
 
     //プロジェクトが終わった際にclaimできる関数

--- a/contracts/GetUp.sol
+++ b/contracts/GetUp.sol
@@ -59,6 +59,7 @@ contract GetUp {
     function createUser(string memory _userName) public {
         User storage user = users[msg.sender];
         require(!user.set); //ユーザー複製禁止のため
+
         unchecked {
             balances[owner] -= 100;
             balances[msg.sender] += 100;
@@ -74,18 +75,6 @@ contract GetUp {
             joined: false,
             canHelloWorld: false
         });
-
-        // string name;
-        // uint256 wokeUpTime; //起きた時間
-        // string joinProject;
-        // bool canGetUpEarly; //ユーザーが早起きできたかどうか
-        // bool joined;
-        // uint256 claimedNumber; // 他のユーザーが自分にclaimした回数
-        // bool set; //ユーザーは1アドレス1つ
-        // bool canHelloWorld;
-
-        // users[msg.sender].push = (User(_userName, 0, "", true, false, 0, true, false));
-
     }
 
     // ユーザーがプロジェクトに参加するための関数
@@ -115,6 +104,7 @@ contract GetUp {
     }
 
     // プロジェクトを作成する関数
+    // ここで変数を多く使っているためstack too deepの原因と予想
     function createProject(
         uint256 _startXDaysLater,
         uint256 _duration,


### PR DESCRIPTION
### stack too deepの原因
16個以上の変数を持つことはできますが、16個以上のスロットの変数を参照しようとすると、一度失敗します。このように、あるコードが失敗する理由は必ずしも明らかではありませんが、いくつかのランダムな変更で解決することがあります。

### Error Code
Compiling 1 file with 0.8.4
CompilerError: Stack too deep when compiling inline assembly: Variable value0 is 1 slot(s) too deep inside the stack.


Error HH600: Compilation failed

For more info go to https://hardhat.org/HH600 or run Hardhat with --show-stack-traces
こちらのリンク→スマートコントラクトにエラーがあるとのことでした